### PR TITLE
document our drive position correction factor

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -105,11 +105,9 @@ public final class Constants {
      *
      * Here's the math:
      *
-     * D_reported = distance reported by `getPosition()`, units matching D_reported
+     * D_reported = distance reported by `getPosition()`, any length unit
      * D_actual = distance measured from the start of the move to the end, units
      * matching D_reported
-     * D_test = distance measured from the stat of the move to the end during the
-     * calibration run, unitsmatching D_reported
      * F_ideal = ideal position factor, computed from gear ratios and wheel
      * diameters
      * C = correction constant.


### PR DESCRIPTION
I am normally anti-"mentors writing PRs", but I realized that explaining/documenting where this weird ratio came from might be worthwhile and I hadn't done so in any other way.

This code does _not_ follow our new standards all the way - happy to move it and the giant comment into the DriveSubsystem class, or have it live wherever in the repo we find appropriate-  please leave comments and ask questions before merging!